### PR TITLE
fix: use system routing to fix Tailscale connectivity

### DIFF
--- a/app/src/main/kotlin/com/sifrlabs/uptimekuma/UptimeRepository.kt
+++ b/app/src/main/kotlin/com/sifrlabs/uptimekuma/UptimeRepository.kt
@@ -1,16 +1,12 @@
 package com.sifrlabs.uptimekuma
 
 import android.content.Context
-import android.net.ConnectivityManager
 import android.util.Base64
 import org.json.JSONObject
 import java.net.HttpURLConnection
 import java.net.URL
 
 class UptimeRepository(private val context: Context) {
-
-    private val connectivityManager =
-        context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
 
     fun fetchGroups(profile: Profile, showGroupMonitors: Boolean = false): List<MonitorGroup> {
         val hostname = profile.hostname
@@ -76,9 +72,7 @@ class UptimeRepository(private val context: Context) {
         }
 
     private fun openConn(url: String, profile: Profile, accept: String): HttpURLConnection {
-        val network = connectivityManager.activeNetwork
-        val conn = (if (network != null) network.openConnection(URL(url))
-                    else URL(url).openConnection()) as HttpURLConnection
+        val conn = URL(url).openConnection() as HttpURLConnection
         conn.connectTimeout = 10_000
         conn.readTimeout    = 15_000
         conn.requestMethod  = "GET"


### PR DESCRIPTION
## Summary

- Removes explicit `activeNetwork.openConnection()` binding in `UptimeRepository`
- Uses `URL(url).openConnection()` instead, which respects the OS routing table

## Why

`connectivityManager.activeNetwork` returns the physical network interface (WiFi/LTE), not the Tailscale VPN tunnel. Calling `network.openConnection()` on it bypasses the VPN, so connections to Tailscale IPs (`100.x.x.x`) fail — even though the browser works fine (it uses system routing).

The fix makes the widget behave like the browser: traffic is routed through the OS routing table, which correctly directs Tailscale addresses through the VPN tunnel.

Users without Tailscale are unaffected.

## Test plan

- [ ] Configure widget with a Tailscale IP (`http://100.x.x.x:port/`)
- [ ] Verify widget refreshes successfully while Tailscale is connected
- [ ] Verify widget still works with a regular hostname (non-Tailscale)

Generated with [Claude Code](https://claude.com/claude-code)